### PR TITLE
Gradle update

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ In your console, head over to the Authorizations tab in the Account Management s
    ```
 
 The build command's output is a jar file with the plugin code and resources.  It can be found in the build/libs folder.  
-The name of the file is zscan-upload-plugin-(build-version).jar, e.g., zscan-upload-plugin-1.15.0.jar.
+The name of the file is zscan-upload-plugin-(build-version).jar, e.g., zscan-upload-plugin-0.1.15.jar.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Please refer to [GoCD Plugin User Guide](https://docs.gocd.org/current/extension
 
 ### Build Prerequisites
 
-- This plugin requires Java 17
-- The build systems uses Gradle.
+- This plugin supports Java versions 17 through 23
+- This plugin targets GoCD version 22.1.0 or later
+- The build systems uses Gradle
 - The plugin uses [Google GSON](https://github.com/google/gson) and [Stipe OkHttp](https://square.github.io/okhttp/) libraries
 
 In your console, head over to the Authorizations tab in the Account Management section and generate a new API key. At a minimum, the following permissions are required:
@@ -35,7 +36,7 @@ In your console, head over to the Authorizations tab in the Account Management s
    ```
 
 The build command's output is a jar file with the plugin code and resources.  It can be found in the build/libs folder.  
-The name of the file is zscan-upload-plugin-(build-version).jar, e.g., zscan-upload-plugin-0.1.10.jar.
+The name of the file is zscan-upload-plugin-(build-version).jar, e.g., zscan-upload-plugin-1.15.0.jar.
 
 ### Usage
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,13 +29,13 @@ def gitRevision = { ->
 project.ext.gitRevision = gitRevision()
 
 group = 'com.zimperium.plugins.zScan'
-version = '0.1.14'
+version = '0.1.15'
 
 // these values that go into plugin.xml
 project.ext.pluginDesc = [
   id         : 'com.zimperium.plugins.zScan',
   version    : project.version,
-  goCdVersion: '19.2.0',
+  goCdVersion: '22.1.0',
   name       : 'zScan Upload Plugin',
   description: 'This plugin can be used to upload applications to Zimperium zScan and receive scan reports.',
   vendorName : 'Zimperium',
@@ -63,7 +63,7 @@ sourceSets {
 }
 
 dependencies {
-  implementation("cd.go.plugin:go-plugin-api:19.2.0")
+  implementation("cd.go.plugin:go-plugin-api:22.1.0")
   implementation("com.google.code.gson:gson:2.11.0")
   implementation("commons-io:commons-io:2.17.0")
   implementation("com.squareup.okhttp3:okhttp:4.12.0")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Update Gradle to 8.12.1 (compatible Java up to 23)
- Update target GoCD version to 22.1.0 (March '22 release)
- Update version to 0.1.15